### PR TITLE
Avoid overlapping logo with book title

### DIFF
--- a/p-front-page.css
+++ b/p-front-page.css
@@ -22,8 +22,8 @@ front-page-title{
 front-page-title {
     background-image: url("images/author_cover_logo.png");
     background-repeat:no-repeat;
-    background-position: 10% center;
-    padding-left: 100px;    
+    background-position: 0 center;
+    padding-left: 110px;    
     padding-top: 20px;
 }
 


### PR DESCRIPTION
When publishing Web Author Customization Guide (https://github.com/oxygenxml/userguide), the logo and the book title would overlap.